### PR TITLE
chore(main): release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# [0.1.1](https://github.com/brpaz/lib-go/compare/v0.1.0...v0.1.1) - 2026-06-11
+
+### 🐛 Bug Fixes
+
+- _(deps)_ update module github.com/pb33f/libopenapi-validator to v0.13.8 (#17) [_(1225f02)_](https://github.com/brpaz/lib-go/commit/1225f02240c1af3d40a6ae3df110444cd600c691) (renovate[bot])
+
+- _(deps)_ update module github.com/jackc/pgx/v5 to v5.10.0 (#18) [_(66c8858)_](https://github.com/brpaz/lib-go/commit/66c88584b0ae05aa8381c52174033c841d60556b) (renovate[bot])
+
+### 🧹 Chore
+
+- updates [_(e364443)_](https://github.com/brpaz/lib-go/commit/e36444324e21a1740f07bf1295a7b5ce88d029b5) (Bruno Paz)
+
+- bump version of db package to correct lib-go version [_(594dea6)_](https://github.com/brpaz/lib-go/commit/594dea63d50791d3def5784691d6f06fc08e09a7) (Bruno Paz)
+
+- _(deps)_ update dorny/paths-filter action to v4 (#24) [_(f430b85)_](https://github.com/brpaz/lib-go/commit/f430b85853dfa4297ecac7695a463c68be0618f3) (renovate[bot])
+
+- add task to release [_(8ba28a1)_](https://github.com/brpaz/lib-go/commit/8ba28a12263ca8aa5d5d70c91f44bc4eb43028d2) (Bruno Paz)
+
 # [0.1.0](https://github.com/brpaz/lib-go/releases/tag/lib-go-v0.1.0) - 2026-06-11
 
 ### 🚀 Features

--- a/db/CHANGELOG.md
+++ b/db/CHANGELOG.md
@@ -12,6 +12,34 @@
 
 - _(deps)_ update module gorm.io/driver/postgres to v1.6.0 (#20) [_(9ac49d3)_](https://github.com/brpaz/lib-go/commit/9ac49d3af4e375048eb4cd5e12a47d0ce84c3e69) (renovate[bot])
 
+- _(deps)_ update module github.com/jackc/pgx/v5 to v5.10.0 (#18) [_(66c8858)_](https://github.com/brpaz/lib-go/commit/66c88584b0ae05aa8381c52174033c841d60556b) (renovate[bot])
+
+### 🧹 Chore
+
+- remove not relevant comment [_(0d2d90c)_](https://github.com/brpaz/lib-go/commit/0d2d90c35dbd20dc76e3a2df4db61172f6397184) (Bruno Paz)
+
+- _(main)_ release (#16) [_(b3621c0)_](https://github.com/brpaz/lib-go/commit/b3621c0ee04f92314bad874c5b2532d5dd9849f4) (Bruno Paz)
+
+- cleanup changelog to retry release [_(34f37ec)_](https://github.com/brpaz/lib-go/commit/34f37ec5bf1b66e23304a19b11d87f503f1cb6ac) (Bruno Paz)
+
+- _(main)_ release (#23) [_(8f17630)_](https://github.com/brpaz/lib-go/commit/8f1763056848a254ec84a56b101d78826f8714a0) (Bruno Paz)
+
+- bump version of db package to correct lib-go version [_(594dea6)_](https://github.com/brpaz/lib-go/commit/594dea63d50791d3def5784691d6f06fc08e09a7) (Bruno Paz)
+
+# [0.1.0](https://github.com/brpaz/lib-go/releases/tag/db/v0.1.0) - 2026-06-11
+
+### 🚀 Features
+
+- _(db)_ add db modules [_(19bb6c3)_](https://github.com/brpaz/lib-go/commit/19bb6c3df8f1b6ce7ddf3e6b882c0d1c24154cad) (Bruno Paz)
+
+- _(db)_ updates [_(3967a3d)_](https://github.com/brpaz/lib-go/commit/3967a3de740edac3057ecbc52d859a6689c55b5b) (Bruno Paz)
+
+- _(db)_ updates [_(60e1181)_](https://github.com/brpaz/lib-go/commit/60e1181a67192284f6959b9dee65db32cfd8e1f6) (Bruno Paz)
+
+### 🐛 Bug Fixes
+
+- _(deps)_ update module gorm.io/driver/postgres to v1.6.0 (#20) [_(9ac49d3)_](https://github.com/brpaz/lib-go/commit/9ac49d3af4e375048eb4cd5e12a47d0ce84c3e69) (renovate[bot])
+
 ### 🧹 Chore
 
 - remove not relevant comment [_(0d2d90c)_](https://github.com/brpaz/lib-go/commit/0d2d90c35dbd20dc76e3a2df4db61172f6397184) (Bruno Paz)


### PR DESCRIPTION
<details>
<summary>db/v0.1.0</summary>
<div id="db-header"></div>
<div id="db" data-tag="db/v0.1.0">
<!--{"metadata":{"tag_compare_link":"","sha_compare_link":""}}-->

# [0.1.0](https://github.com/brpaz/lib-go/releases/tag/db/v0.1.0) - 2026-06-11

### 🚀 Features

- _(db)_ add db modules [_(19bb6c3)_](https://github.com/brpaz/lib-go/commit/19bb6c3df8f1b6ce7ddf3e6b882c0d1c24154cad) (Bruno Paz)

- _(db)_ updates [_(3967a3d)_](https://github.com/brpaz/lib-go/commit/3967a3de740edac3057ecbc52d859a6689c55b5b) (Bruno Paz)

- _(db)_ updates [_(60e1181)_](https://github.com/brpaz/lib-go/commit/60e1181a67192284f6959b9dee65db32cfd8e1f6) (Bruno Paz)

### 🐛 Bug Fixes

- _(deps)_ update module gorm.io/driver/postgres to v1.6.0 (#20) [_(9ac49d3)_](https://github.com/brpaz/lib-go/commit/9ac49d3af4e375048eb4cd5e12a47d0ce84c3e69) (renovate[bot])

- _(deps)_ update module github.com/jackc/pgx/v5 to v5.10.0 (#18) [_(66c8858)_](https://github.com/brpaz/lib-go/commit/66c88584b0ae05aa8381c52174033c841d60556b) (renovate[bot])

### 🧹 Chore

- remove not relevant comment [_(0d2d90c)_](https://github.com/brpaz/lib-go/commit/0d2d90c35dbd20dc76e3a2df4db61172f6397184) (Bruno Paz)

- _(main)_ release (#16) [_(b3621c0)_](https://github.com/brpaz/lib-go/commit/b3621c0ee04f92314bad874c5b2532d5dd9849f4) (Bruno Paz)

- cleanup changelog to retry release [_(34f37ec)_](https://github.com/brpaz/lib-go/commit/34f37ec5bf1b66e23304a19b11d87f503f1cb6ac) (Bruno Paz)

- _(main)_ release (#23) [_(8f17630)_](https://github.com/brpaz/lib-go/commit/8f1763056848a254ec84a56b101d78826f8714a0) (Bruno Paz)

- bump version of db package to correct lib-go version [_(594dea6)_](https://github.com/brpaz/lib-go/commit/594dea63d50791d3def5784691d6f06fc08e09a7) (Bruno Paz)
</div>
<div id="db-footer"></div>
</details>
<details>
<summary>v0.1.1</summary>
<div id="lib-go-header"></div>
<div id="lib-go" data-tag="v0.1.1">
<!--{"metadata":{"tag_compare_link":"https://github.com/brpaz/lib-go/compare/v0.1.0...v0.1.1","sha_compare_link":"https://github.com/brpaz/lib-go/compare/v0.1.0...8ba28a12263ca8aa5d5d70c91f44bc4eb43028d2"}}-->

# [0.1.1](https://github.com/brpaz/lib-go/compare/v0.1.0...8ba28a12263ca8aa5d5d70c91f44bc4eb43028d2) - 2026-06-11

### 🐛 Bug Fixes

- _(deps)_ update module github.com/pb33f/libopenapi-validator to v0.13.8 (#17) [_(1225f02)_](https://github.com/brpaz/lib-go/commit/1225f02240c1af3d40a6ae3df110444cd600c691) (renovate[bot])

- _(deps)_ update module github.com/jackc/pgx/v5 to v5.10.0 (#18) [_(66c8858)_](https://github.com/brpaz/lib-go/commit/66c88584b0ae05aa8381c52174033c841d60556b) (renovate[bot])

### 🧹 Chore

- updates [_(e364443)_](https://github.com/brpaz/lib-go/commit/e36444324e21a1740f07bf1295a7b5ce88d029b5) (Bruno Paz)

- bump version of db package to correct lib-go version [_(594dea6)_](https://github.com/brpaz/lib-go/commit/594dea63d50791d3def5784691d6f06fc08e09a7) (Bruno Paz)

- _(deps)_ update dorny/paths-filter action to v4 (#24) [_(f430b85)_](https://github.com/brpaz/lib-go/commit/f430b85853dfa4297ecac7695a463c68be0618f3) (renovate[bot])

- add task to release [_(8ba28a1)_](https://github.com/brpaz/lib-go/commit/8ba28a12263ca8aa5d5d70c91f44bc4eb43028d2) (Bruno Paz)
</div>
<div id="lib-go-footer"></div>
</details>